### PR TITLE
Add usage baseline reconciliation tooling

### DIFF
--- a/PROJECT_PROGRESS.md
+++ b/PROJECT_PROGRESS.md
@@ -1,5 +1,29 @@
 # Project Progress
 
+## 2026-04-13
+
+### Usage baseline consolidation and reconciliation tooling
+
+* Extended Powerpal minute loader to support manifest-based batch processing and dry-run coverage summaries.
+* Added per-file and aggregate diagnostics for Powerpal exports:
+  * header-only exports are skipped cleanly;
+  * UTC timestamp parsing remains direct for `datetime_utc`;
+  * `watt_hours` remains converted to kWh;
+  * Powerpal `cost_dollars` is intentionally not mapped to `cost_aud`.
+* Local Powerpal manifest dry run found:
+  * first real interval: `2025-01-04 00:00:00+00:00` (`2025-01-04 11:00 Australia/Sydney`);
+  * last real interval: `2026-01-04 23:59:00+00:00`;
+  * aggregate valid rows before de-duplicating overlapping exports: `656,739`;
+  * duplicate interval starts from overlapping exports: `130,111`;
+  * detected gaps inside observed range: `26`;
+  * missing minutes inside observed range: `412`;
+  * Oct-Dec 2024 export attempts remain header-only.
+* Added `scripts/compare_usage_sources.py` to compare daily Supabase usage totals between Powerpal and Amber by Australia/Sydney local day.
+* Verification:
+  * `.venv/bin/python -m pytest -q` -> `35 passed`.
+  * `.venv/bin/python scripts/load_powerpal_minute_to_supabase.py --manifest data_raw/powerpal_minute/manifest_powerpal_minute.csv --dry-run` -> completed successfully.
+* Live Supabase load and reconciliation remain blocked locally because the configured Supabase URL currently fails with `Tenant or user not found`.
+
 ## 2026-02-08
 
 ### Digital twin simulation (10 kW PV + 10 kWh battery)

--- a/scripts/compare_usage_sources.py
+++ b/scripts/compare_usage_sources.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+"""Compare daily usage totals between two Supabase usage sources."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from datetime import date, datetime, time, timedelta, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, Optional, Sequence
+
+import pandas as pd
+from dotenv import load_dotenv
+from zoneinfo import ZoneInfo
+
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root / "src"))
+
+from home_energy_analysis.storage import supabase_db
+
+TZ = ZoneInfo("Australia/Sydney")
+
+
+def parse_yyyy_mm_dd(value: str) -> date:
+    """Parse a YYYY-MM-DD local date."""
+    try:
+        return date.fromisoformat(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"Invalid date '{value}', expected YYYY-MM-DD") from exc
+
+
+def local_date_window(start_date: date, end_date: date) -> tuple[datetime, datetime]:
+    """Convert inclusive Sydney-local date range to UTC [start, end) datetimes."""
+    if start_date > end_date:
+        raise ValueError("--start must be on or before --end")
+    start_local = datetime.combine(start_date, time.min, tzinfo=TZ)
+    end_local_exclusive = datetime.combine(end_date + timedelta(days=1), time.min, tzinfo=TZ)
+    return start_local.astimezone(timezone.utc), end_local_exclusive.astimezone(timezone.utc)
+
+
+def expected_minutes_for_local_day(local_day: date) -> int:
+    """Return actual minutes in a Sydney-local day, including DST transition days."""
+    start_local = datetime.combine(local_day, time.min, tzinfo=TZ)
+    end_local = datetime.combine(local_day + timedelta(days=1), time.min, tzinfo=TZ)
+    return int((end_local.astimezone(timezone.utc) - start_local.astimezone(timezone.utc)).total_seconds() // 60)
+
+
+def _date_range(start_date: date, end_date: date) -> list[date]:
+    current = start_date
+    days: list[date] = []
+    while current <= end_date:
+        days.append(current)
+        current += timedelta(days=1)
+    return days
+
+
+def load_usage_rows(
+    site_id: str,
+    channel_type: str,
+    sources: Sequence[str],
+    start_utc: datetime,
+    end_utc: datetime,
+) -> list[Dict[str, Any]]:
+    """Load usage rows from Supabase for the requested sources and UTC window."""
+    with supabase_db.get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT source, interval_start, interval_end, kwh
+                FROM usage_intervals
+                WHERE site_id = %s
+                  AND channel_type = %s
+                  AND source = ANY(%s)
+                  AND interval_start >= %s
+                  AND interval_start < %s
+                ORDER BY source, interval_start
+                """,
+                (site_id, channel_type, list(sources), start_utc, end_utc),
+            )
+            rows = cur.fetchall()
+
+    return [
+        {
+            "source": row[0],
+            "interval_start": row[1],
+            "interval_end": row[2],
+            "kwh": float(row[3]) if row[3] is not None else None,
+        }
+        for row in rows
+    ]
+
+
+def aggregate_daily(
+    rows: Iterable[Dict[str, Any]],
+    start_date: date,
+    end_date: date,
+    sources: Sequence[str],
+) -> pd.DataFrame:
+    """Aggregate usage rows by Sydney-local day and source."""
+    days = _date_range(start_date, end_date)
+    grid = pd.MultiIndex.from_product([sources, days], names=["source", "local_date"]).to_frame(index=False)
+    grid["expected_minutes"] = grid["local_date"].apply(expected_minutes_for_local_day)
+
+    df = pd.DataFrame(list(rows))
+    if df.empty:
+        grouped = pd.DataFrame(columns=[
+            "source",
+            "local_date",
+            "kwh_total",
+            "covered_minutes",
+            "interval_count",
+            "first_interval_start",
+            "last_interval_end",
+        ])
+    else:
+        df["interval_start"] = pd.to_datetime(df["interval_start"], utc=True)
+        df["interval_end"] = pd.to_datetime(df["interval_end"], utc=True)
+        df["kwh"] = pd.to_numeric(df["kwh"], errors="coerce")
+        df["local_date"] = df["interval_start"].dt.tz_convert(TZ).dt.date
+        df["duration_minutes"] = (
+            (df["interval_end"] - df["interval_start"]).dt.total_seconds() / 60.0
+        ).clip(lower=0)
+
+        grouped = (
+            df.groupby(["source", "local_date"], as_index=False)
+            .agg(
+                kwh_total=("kwh", "sum"),
+                covered_minutes=("duration_minutes", "sum"),
+                interval_count=("kwh", "count"),
+                first_interval_start=("interval_start", "min"),
+                last_interval_end=("interval_end", "max"),
+            )
+        )
+
+    daily = grid.merge(grouped, on=["source", "local_date"], how="left")
+    daily["covered_minutes"] = daily["covered_minutes"].fillna(0.0)
+    daily["interval_count"] = daily["interval_count"].fillna(0).astype(int)
+    daily["missing_coverage_minutes"] = (
+        daily["expected_minutes"] - daily["covered_minutes"]
+    ).clip(lower=0)
+
+    present_mask = daily["interval_count"] > 0
+    daily.loc[~present_mask, "kwh_total"] = pd.NA
+    daily["covered_minutes"] = daily["covered_minutes"].round(3)
+    daily["missing_coverage_minutes"] = daily["missing_coverage_minutes"].round(3)
+    return daily.sort_values(["local_date", "source"]).reset_index(drop=True)
+
+
+def build_reconciliation(daily: pd.DataFrame, source_a: str, source_b: str) -> pd.DataFrame:
+    """Build daily source-vs-source reconciliation table."""
+    a = daily[daily["source"] == source_a].copy()
+    b = daily[daily["source"] == source_b].copy()
+
+    a = a.rename(columns={
+        "kwh_total": f"{source_a}_kwh",
+        "covered_minutes": f"{source_a}_covered_minutes",
+        "missing_coverage_minutes": f"{source_a}_missing_minutes",
+        "interval_count": f"{source_a}_interval_count",
+    })
+    b = b.rename(columns={
+        "kwh_total": f"{source_b}_kwh",
+        "covered_minutes": f"{source_b}_covered_minutes",
+        "missing_coverage_minutes": f"{source_b}_missing_minutes",
+        "interval_count": f"{source_b}_interval_count",
+    })
+
+    keep_a = [
+        "local_date",
+        "expected_minutes",
+        f"{source_a}_kwh",
+        f"{source_a}_covered_minutes",
+        f"{source_a}_missing_minutes",
+        f"{source_a}_interval_count",
+    ]
+    keep_b = [
+        "local_date",
+        f"{source_b}_kwh",
+        f"{source_b}_covered_minutes",
+        f"{source_b}_missing_minutes",
+        f"{source_b}_interval_count",
+    ]
+
+    reconciliation = a[keep_a].merge(b[keep_b], on="local_date", how="outer")
+    reconciliation["diff_kwh"] = reconciliation[f"{source_a}_kwh"] - reconciliation[f"{source_b}_kwh"]
+    denominator = reconciliation[f"{source_a}_kwh"].replace({0: pd.NA})
+    reconciliation[f"diff_pct_vs_{source_a}"] = (reconciliation["diff_kwh"] / denominator) * 100.0
+    return reconciliation.sort_values("local_date").reset_index(drop=True)
+
+
+def reconciliation_stats(reconciliation: pd.DataFrame, source_a: str, source_b: str) -> Dict[str, Any]:
+    """Compute summary stats for a reconciliation table."""
+    a_col = f"{source_a}_kwh"
+    b_col = f"{source_b}_kwh"
+    overlap = reconciliation.dropna(subset=[a_col, b_col]).copy()
+    missing_a = reconciliation[reconciliation[a_col].isna()]
+    missing_b = reconciliation[reconciliation[b_col].isna()]
+
+    stats: Dict[str, Any] = {
+        "overlap_days": int(len(overlap)),
+        f"days_missing_{source_a}": int(len(missing_a)),
+        f"days_missing_{source_b}": int(len(missing_b)),
+        "mean_abs_diff_kwh": None,
+        "median_abs_diff_kwh": None,
+        "max_abs_diff_kwh": None,
+        "correlation": None,
+    }
+
+    if not overlap.empty:
+        abs_diff = overlap["diff_kwh"].abs()
+        stats["mean_abs_diff_kwh"] = float(abs_diff.mean())
+        stats["median_abs_diff_kwh"] = float(abs_diff.median())
+        stats["max_abs_diff_kwh"] = float(abs_diff.max())
+        if len(overlap) >= 2:
+            stats["correlation"] = float(overlap[[a_col, b_col]].corr().iloc[0, 1])
+    return stats
+
+
+def print_report(reconciliation: pd.DataFrame, stats: Dict[str, Any], source_a: str, source_b: str) -> None:
+    """Print concise reconciliation summary."""
+    print("=== Usage source reconciliation ===")
+    print(f"Source A: {source_a}")
+    print(f"Source B: {source_b}")
+    print(f"Days in report: {len(reconciliation)}")
+    for key, value in stats.items():
+        print(f"{key}: {value}")
+
+    print()
+    print("First 10 daily rows:")
+    display_cols = [
+        "local_date",
+        f"{source_a}_kwh",
+        f"{source_b}_kwh",
+        "diff_kwh",
+        f"diff_pct_vs_{source_a}",
+        f"{source_a}_missing_minutes",
+        f"{source_b}_missing_minutes",
+    ]
+    print(reconciliation[display_cols].head(10).to_string(index=False))
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="Compare usage totals between two Supabase sources")
+    parser.add_argument("--start", required=True, type=parse_yyyy_mm_dd,
+                        help="Start date YYYY-MM-DD in Australia/Sydney")
+    parser.add_argument("--end", required=True, type=parse_yyyy_mm_dd,
+                        help="End date YYYY-MM-DD in Australia/Sydney, inclusive")
+    parser.add_argument("--site-id", default=None,
+                        help="Site ID (default: AMBER_SITE_ID env var)")
+    parser.add_argument("--channel-type", default="general",
+                        help="Channel type (default: general)")
+    parser.add_argument("--source-a", default="powerpal",
+                        help="First source, used as percentage denominator (default: powerpal)")
+    parser.add_argument("--source-b", default="amber",
+                        help="Second source to compare against source-a (default: amber)")
+    parser.add_argument("--out-csv", type=Path, default=None,
+                        help="Optional output CSV path")
+
+    args = parser.parse_args(argv)
+
+    load_dotenv(project_root / ".env.local", override=False)
+
+    site_id = args.site_id or os.getenv("AMBER_SITE_ID")
+    if not site_id:
+        print("ERROR: --site-id required or AMBER_SITE_ID must be set", file=sys.stderr)
+        return 1
+    if not os.getenv("SUPABASE_DB_URL"):
+        print("ERROR: SUPABASE_DB_URL environment variable is required", file=sys.stderr)
+        return 1
+
+    try:
+        start_utc, end_utc = local_date_window(args.start, args.end)
+        print(f"Local window: {args.start} to {args.end} Australia/Sydney")
+        print(f"UTC query window: {start_utc.isoformat()} to {end_utc.isoformat()} [exclusive]")
+
+        rows = load_usage_rows(
+            site_id,
+            args.channel_type,
+            [args.source_a, args.source_b],
+            start_utc,
+            end_utc,
+        )
+        daily = aggregate_daily(rows, args.start, args.end, [args.source_a, args.source_b])
+        reconciliation = build_reconciliation(daily, args.source_a, args.source_b)
+        stats = reconciliation_stats(reconciliation, args.source_a, args.source_b)
+        print_report(reconciliation, stats, args.source_a, args.source_b)
+
+        if args.out_csv:
+            args.out_csv.parent.mkdir(parents=True, exist_ok=True)
+            reconciliation.to_csv(args.out_csv, index=False)
+            print(f"Saved daily reconciliation CSV: {args.out_csv}")
+    except Exception as e:
+        print(f"ERROR: Failed to compare usage sources: {e}", file=sys.stderr)
+        import traceback
+        traceback.print_exc()
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/load_powerpal_minute_to_supabase.py
+++ b/scripts/load_powerpal_minute_to_supabase.py
@@ -17,9 +17,10 @@ CLI options:
 import argparse
 import os
 import sys
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Dict, Any, List, Optional
+from typing import Dict, Any, List, Optional, Sequence
 
 import pandas as pd
 from dotenv import load_dotenv
@@ -36,6 +37,26 @@ load_dotenv(project_root / ".env.local", override=False)
 from home_energy_analysis.storage import supabase_db
 
 TZ = ZoneInfo("Australia/Sydney")
+
+
+@dataclass
+class FileLoadSummary:
+    """Summary of a parsed Powerpal CSV file."""
+
+    path: Path
+    input_rows: int
+    valid_intervals: int
+    dropped_invalid_rows: int
+    invalid_timestamp_rows: int
+    duplicate_intervals: int
+    gap_count: int
+    missing_minutes: int
+    first_interval_start: Optional[datetime]
+    last_interval_start: Optional[datetime]
+    last_interval_end: Optional[datetime]
+    parse_mode_msg: str
+    is_empty: bool = False
+    upserted_count: Optional[int] = None
 
 
 def detect_timestamp_column(df: pd.DataFrame) -> Optional[str]:
@@ -205,125 +226,277 @@ def build_usage_intervals(
     return rows, na_count, parse_mode_msg
 
 
-def main() -> int:
+def summarize_intervals(
+    csv_path: Path,
+    df_row_count: int,
+    rows: List[Dict[str, Any]],
+    invalid_timestamp_rows: int,
+    parse_mode_msg: str,
+    is_empty: bool = False,
+) -> FileLoadSummary:
+    """Build per-file interval coverage diagnostics."""
+    starts = [row["interval_start"] for row in rows]
+    unique_starts = sorted(set(starts))
+    duplicate_intervals = len(starts) - len(unique_starts)
+    dropped_invalid_rows = df_row_count - len(rows)
+
+    gap_count = 0
+    missing_minutes = 0
+    if len(unique_starts) > 1:
+        previous = unique_starts[0]
+        for current in unique_starts[1:]:
+            gap_minutes = int((current - previous).total_seconds() // 60)
+            if gap_minutes > 1:
+                gap_count += 1
+                missing_minutes += gap_minutes - 1
+            previous = current
+
+    first_interval_start = unique_starts[0] if unique_starts else None
+    last_interval_start = unique_starts[-1] if unique_starts else None
+    last_interval_end = None
+    if rows:
+        last_interval_end = max(row["interval_end"] for row in rows)
+
+    return FileLoadSummary(
+        path=csv_path,
+        input_rows=df_row_count,
+        valid_intervals=len(rows),
+        dropped_invalid_rows=dropped_invalid_rows,
+        invalid_timestamp_rows=invalid_timestamp_rows,
+        duplicate_intervals=duplicate_intervals,
+        gap_count=gap_count,
+        missing_minutes=missing_minutes,
+        first_interval_start=first_interval_start,
+        last_interval_start=last_interval_start,
+        last_interval_end=last_interval_end,
+        parse_mode_msg=parse_mode_msg,
+        is_empty=is_empty,
+    )
+
+
+def print_file_summary(summary: FileLoadSummary) -> None:
+    """Print a concise per-file load/dry-run summary."""
+    print(f"Summary for {summary.path}:")
+    if summary.is_empty:
+        print("  Empty/header-only CSV: skipped")
+        return
+    print(f"  Input rows: {summary.input_rows}")
+    print(f"  Valid intervals: {summary.valid_intervals}")
+    print(f"  Dropped invalid rows: {summary.dropped_invalid_rows}")
+    print(f"  Invalid timestamp rows: {summary.invalid_timestamp_rows}")
+    print(f"  Duplicate intervals: {summary.duplicate_intervals}")
+    print(f"  Gap count: {summary.gap_count}")
+    print(f"  Missing minutes inside range: {summary.missing_minutes}")
+    print(f"  First interval start: {summary.first_interval_start}")
+    print(f"  Last interval start: {summary.last_interval_start}")
+    print(f"  Last interval end: {summary.last_interval_end}")
+    if summary.upserted_count is not None:
+        print(f"  Upserted intervals: {summary.upserted_count}")
+
+
+def summarize_aggregate(summaries: Sequence[FileLoadSummary], all_rows: List[Dict[str, Any]]) -> FileLoadSummary:
+    """Build aggregate coverage diagnostics across all processed files."""
+    input_rows = sum(summary.input_rows for summary in summaries)
+    invalid_timestamp_rows = sum(summary.invalid_timestamp_rows for summary in summaries)
+    summary = summarize_intervals(
+        Path("<aggregate>"),
+        input_rows,
+        all_rows,
+        invalid_timestamp_rows,
+        "Aggregate across processed files",
+        is_empty=not bool(all_rows),
+    )
+    return summary
+
+
+def read_powerpal_csv(csv_path: Path) -> pd.DataFrame:
+    """Read a Powerpal CSV file and strip column whitespace."""
+    df = pd.read_csv(csv_path)
+    df.columns = [c.strip() for c in df.columns]
+    return df
+
+
+def manifest_csv_paths(manifest_path: Path) -> List[Path]:
+    """Return CSV file paths from a Powerpal manifest, preserving first-seen order."""
+    manifest_df = pd.read_csv(manifest_path)
+    if "file" not in manifest_df.columns:
+        raise ValueError(f"Manifest missing required 'file' column: {manifest_path}")
+
+    paths: List[Path] = []
+    seen: set[str] = set()
+    for raw_path in manifest_df["file"].dropna().astype(str):
+        if raw_path in seen:
+            continue
+        seen.add(raw_path)
+        path = Path(raw_path)
+        if not path.is_absolute():
+            path = project_root / path
+        paths.append(path)
+    return paths
+
+
+def process_csv_file(
+    csv_path: Path,
+    site_id: str,
+    channel_type: str,
+    source: str,
+    dry_run: bool,
+    conn=None,
+) -> tuple[FileLoadSummary, List[Dict[str, Any]]]:
+    """Parse, summarize, and optionally load a single Powerpal CSV file."""
+    if not csv_path.exists():
+        raise FileNotFoundError(f"CSV file not found: {csv_path}")
+
+    print(f"Reading CSV: {csv_path}")
+    df = read_powerpal_csv(csv_path)
+    print(f"  Loaded {len(df)} rows")
+    print(f"  Columns: {list(df.columns)}")
+
+    if len(df) == 0:
+        summary = summarize_intervals(csv_path, 0, [], 0, "No data rows", is_empty=True)
+        print_file_summary(summary)
+        return summary, []
+
+    timestamp_col = detect_timestamp_column(df)
+    if timestamp_col is None:
+        raise ValueError(f"Could not detect timestamp column. Columns: {list(df.columns)}")
+
+    kwh_col = detect_kwh_column(df)
+    if kwh_col is None:
+        raise ValueError(f"Could not detect kWh column. Columns: {list(df.columns)}")
+
+    print(f"  Using timestamp column: {timestamp_col}")
+    print(f"  Using kWh column: {kwh_col}")
+
+    raw_event_id = "dry-run"
+    if not dry_run:
+        payload_dict = {
+            "file": str(csv_path),
+            "row_count": len(df),
+            "site_id": site_id,
+            "source": source,
+            "channel_type": channel_type,
+        }
+        raw_event_id = supabase_db.insert_ingest_event(
+            conn, source, "usage", payload_dict,
+            window_start=None, window_end=None
+        )
+        print(f"Created ingest event: {raw_event_id}")
+
+    print("Building usage intervals...")
+    rows, na_count, parse_mode_msg = build_usage_intervals(
+        df, timestamp_col, kwh_col,
+        site_id, channel_type, source, raw_event_id
+    )
+
+    print(f"  {parse_mode_msg}")
+    summary = summarize_intervals(csv_path, len(df), rows, na_count, parse_mode_msg)
+
+    if not rows:
+        print_file_summary(summary)
+        return summary, rows
+
+    if not dry_run:
+        print("Upserting to database...")
+        summary.upserted_count = supabase_db.upsert_usage_intervals(conn, rows)
+
+    print_file_summary(summary)
+    return summary, rows
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
     """Main entry point."""
     parser = argparse.ArgumentParser(
         description="Load Powerpal minute CSV into Supabase usage_intervals"
     )
-    parser.add_argument("--csv", required=True, type=Path,
-                        help="Path to CSV file")
+    input_group = parser.add_mutually_exclusive_group(required=True)
+    input_group.add_argument("--csv", type=Path,
+                             help="Path to one CSV file")
+    input_group.add_argument("--manifest", type=Path,
+                             help="Path to manifest CSV listing Powerpal files")
     parser.add_argument("--site-id", type=str, default=None,
                         help="Site ID (default: AMBER_SITE_ID env var)")
     parser.add_argument("--source", type=str, default="powerpal",
                         help="Source identifier (default: powerpal)")
     parser.add_argument("--channel-type", type=str, default="general",
                         help="Channel type (default: general)")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Parse and summarize files without connecting to Supabase")
     
-    args = parser.parse_args()
-    
-    # Validate CSV file exists
-    if not args.csv.exists():
-        print(f"ERROR: CSV file not found: {args.csv}", file=sys.stderr)
-        return 1
+    args = parser.parse_args(argv)
     
     # Get site_id
-    site_id = args.site_id or os.getenv("AMBER_SITE_ID")
+    site_id = args.site_id or os.getenv("AMBER_SITE_ID") or ("dry-run-site" if args.dry_run else None)
     if not site_id:
         print("ERROR: --site-id required or AMBER_SITE_ID must be set", file=sys.stderr)
         return 1
     
     # Check database connection
-    if not os.getenv("SUPABASE_DB_URL"):
+    if not args.dry_run and not os.getenv("SUPABASE_DB_URL"):
         print("ERROR: SUPABASE_DB_URL environment variable is required", file=sys.stderr)
         return 1
-    
-    # Read CSV
-    print(f"Reading CSV: {args.csv}")
+
+    if args.csv:
+        csv_paths = [args.csv]
+    else:
+        if not args.manifest.exists():
+            print(f"ERROR: Manifest file not found: {args.manifest}", file=sys.stderr)
+            return 1
+        try:
+            csv_paths = manifest_csv_paths(args.manifest)
+        except Exception as e:
+            print(f"ERROR: Failed to read manifest: {e}", file=sys.stderr)
+            return 1
+
+    if not csv_paths:
+        print("ERROR: No CSV files found to process", file=sys.stderr)
+        return 1
+
+    conn = None
+    if not args.dry_run:
+        try:
+            conn = supabase_db.get_conn()
+        except Exception as e:
+            print(f"ERROR: Failed to connect to database: {e}", file=sys.stderr)
+            return 1
+
+    summaries: List[FileLoadSummary] = []
+    all_rows: List[Dict[str, Any]] = []
+
     try:
-        df = pd.read_csv(args.csv)
-        df.columns = [c.strip() for c in df.columns]  # Strip whitespace from column names
-        print(f"  Loaded {len(df)} rows")
-        print(f"  Columns: {list(df.columns)}")
-    except Exception as e:
-        print(f"ERROR: Failed to read CSV: {e}", file=sys.stderr)
-        return 1
-    
-    if len(df) == 0:
-        print("ERROR: CSV file is empty", file=sys.stderr)
-        return 1
-    
-    # Detect columns
-    timestamp_col = detect_timestamp_column(df)
-    if timestamp_col is None:
-        print(f"ERROR: Could not detect timestamp column. Columns: {list(df.columns)}", file=sys.stderr)
-        return 1
-    
-    kwh_col = detect_kwh_column(df)
-    if kwh_col is None:
-        print(f"ERROR: Could not detect kWh column. Columns: {list(df.columns)}", file=sys.stderr)
-        return 1
-    
-    print(f"  Using timestamp column: {timestamp_col}")
-    print(f"  Using kWh column: {kwh_col}")
-    
-    # Connect to database
-    try:
-        conn = supabase_db.get_conn()
-    except Exception as e:
-        print(f"ERROR: Failed to connect to database: {e}", file=sys.stderr)
-        return 1
-    
-    try:
-        # Create ingest event
-        payload_dict = {
-            "file": str(args.csv),
-            "row_count": len(df),
-            "site_id": site_id,
-            "source": args.source,
-            "channel_type": args.channel_type,
-        }
-        
-        # Determine time window from data (optional, will be computed from intervals)
-        window_start = None
-        window_end = None
-        # We'll compute this after parsing timestamps, but it's optional
-        
-        raw_event_id = supabase_db.insert_ingest_event(
-            conn, args.source, "usage", payload_dict,
-            window_start=window_start, window_end=window_end
-        )
-        print(f"Created ingest event: {raw_event_id}")
-        
-        # Build usage intervals
-        print("Building usage intervals...")
-        rows, na_count, parse_mode_msg = build_usage_intervals(
-            df, timestamp_col, kwh_col,
-            site_id, args.channel_type, args.source, raw_event_id
-        )
-        
-        # Log parse mode and NaT count
-        print(f"  {parse_mode_msg}")
-        if na_count > 0:
-            print(f"  Warning: Dropped {na_count} rows with invalid timestamps (NaT)")
-        print(f"  Built {len(rows)} intervals")
-        
-        if len(rows) == 0:
+        for csv_path in csv_paths:
+            summary, rows = process_csv_file(
+                csv_path,
+                site_id,
+                args.channel_type,
+                args.source,
+                args.dry_run,
+                conn=conn,
+            )
+            summaries.append(summary)
+            all_rows.extend(rows)
+            print()
+
+        aggregate = summarize_aggregate(summaries, all_rows)
+        print("=== Aggregate coverage ===")
+        print_file_summary(aggregate)
+        if args.dry_run:
+            print("Dry run complete; no Supabase writes were attempted.")
+
+        if args.csv and not all_rows:
             print("ERROR: No valid intervals found", file=sys.stderr)
             return 1
-        
-        # Upsert to database
-        print("Upserting to database...")
-        count = supabase_db.upsert_usage_intervals(conn, rows)
-        print(f"✓ Upserted {count} usage intervals")
-        
+
     except Exception as e:
         print(f"ERROR: Failed to process data: {e}", file=sys.stderr)
         import traceback
         traceback.print_exc()
-        conn.rollback()
+        if conn:
+            conn.rollback()
         return 1
     finally:
-        conn.close()
+        if conn:
+            conn.close()
     
     return 0
 

--- a/tests/test_compare_usage_sources.py
+++ b/tests/test_compare_usage_sources.py
@@ -1,0 +1,84 @@
+"""Tests for usage source reconciliation helpers."""
+
+from datetime import date, datetime, timezone
+
+import pandas as pd
+import pytest
+
+from scripts import compare_usage_sources as compare
+
+
+def test_local_date_window_uses_sydney_boundaries():
+    start_utc, end_utc = compare.local_date_window(date(2025, 1, 4), date(2025, 1, 5))
+
+    assert start_utc == datetime(2025, 1, 3, 13, 0, tzinfo=timezone.utc)
+    assert end_utc == datetime(2025, 1, 5, 13, 0, tzinfo=timezone.utc)
+
+
+def test_aggregate_daily_handles_mixed_interval_lengths():
+    rows = [
+        {
+            "source": "powerpal",
+            "interval_start": datetime(2025, 1, 3, 13, 0, tzinfo=timezone.utc),
+            "interval_end": datetime(2025, 1, 3, 13, 1, tzinfo=timezone.utc),
+            "kwh": 0.1,
+        },
+        {
+            "source": "powerpal",
+            "interval_start": datetime(2025, 1, 3, 13, 1, tzinfo=timezone.utc),
+            "interval_end": datetime(2025, 1, 3, 13, 2, tzinfo=timezone.utc),
+            "kwh": 0.2,
+        },
+        {
+            "source": "amber",
+            "interval_start": datetime(2025, 1, 3, 13, 0, tzinfo=timezone.utc),
+            "interval_end": datetime(2025, 1, 3, 13, 30, tzinfo=timezone.utc),
+            "kwh": 3.0,
+        },
+    ]
+
+    daily = compare.aggregate_daily(rows, date(2025, 1, 4), date(2025, 1, 4), ["powerpal", "amber"])
+
+    powerpal = daily[daily["source"] == "powerpal"].iloc[0]
+    amber = daily[daily["source"] == "amber"].iloc[0]
+    assert powerpal["kwh_total"] == pytest.approx(0.3)
+    assert powerpal["covered_minutes"] == 2.0
+    assert powerpal["missing_coverage_minutes"] == 1438.0
+    assert amber["kwh_total"] == 3.0
+    assert amber["covered_minutes"] == 30.0
+    assert amber["missing_coverage_minutes"] == 1410.0
+
+
+def test_reconciliation_reports_missing_source_days_and_diff():
+    rows = [
+        {
+            "source": "powerpal",
+            "interval_start": datetime(2025, 1, 3, 13, 0, tzinfo=timezone.utc),
+            "interval_end": datetime(2025, 1, 3, 13, 1, tzinfo=timezone.utc),
+            "kwh": 1.0,
+        },
+        {
+            "source": "amber",
+            "interval_start": datetime(2025, 1, 3, 13, 0, tzinfo=timezone.utc),
+            "interval_end": datetime(2025, 1, 3, 13, 30, tzinfo=timezone.utc),
+            "kwh": 0.8,
+        },
+        {
+            "source": "powerpal",
+            "interval_start": datetime(2025, 1, 4, 13, 0, tzinfo=timezone.utc),
+            "interval_end": datetime(2025, 1, 4, 13, 1, tzinfo=timezone.utc),
+            "kwh": 2.0,
+        },
+    ]
+    daily = compare.aggregate_daily(rows, date(2025, 1, 4), date(2025, 1, 5), ["powerpal", "amber"])
+
+    reconciliation = compare.build_reconciliation(daily, "powerpal", "amber")
+    stats = compare.reconciliation_stats(reconciliation, "powerpal", "amber")
+
+    first_day = reconciliation[reconciliation["local_date"] == date(2025, 1, 4)].iloc[0]
+    second_day = reconciliation[reconciliation["local_date"] == date(2025, 1, 5)].iloc[0]
+    assert first_day["diff_kwh"] == pytest.approx(0.2)
+    assert pd.isna(second_day["amber_kwh"])
+    assert stats["overlap_days"] == 1
+    assert stats["days_missing_amber"] == 1
+    assert stats["days_missing_powerpal"] == 0

--- a/tests/test_powerpal_loader.py
+++ b/tests/test_powerpal_loader.py
@@ -1,0 +1,88 @@
+"""Tests for Powerpal minute CSV loader helpers."""
+
+from datetime import timezone
+from pathlib import Path
+
+import pandas as pd
+
+from scripts import load_powerpal_minute_to_supabase as loader
+
+
+def test_build_usage_intervals_uses_utc_timestamp_and_watt_hours():
+    df = pd.DataFrame({
+        "datetime_utc": ["2025-01-04 00:00:00"],
+        "datetime_local": ["2025-01-04 11:00:00"],
+        "watt_hours": [6.0],
+        "cost_dollars": [0.01],
+    })
+
+    rows, na_count, parse_mode = loader.build_usage_intervals(
+        df,
+        "datetime_utc",
+        "watt_hours",
+        site_id="site",
+        channel_type="general",
+        source="powerpal",
+        raw_event_id="dry-run",
+    )
+
+    assert na_count == 0
+    assert "UTC directly" in parse_mode
+    assert rows[0]["interval_start"].tzinfo == timezone.utc
+    assert rows[0]["interval_start"].isoformat() == "2025-01-04T00:00:00+00:00"
+    assert rows[0]["kwh"] == 0.006
+    assert rows[0]["cost_aud"] is None
+
+
+def test_manifest_dry_run_skips_header_only_csv(tmp_path, capsys):
+    csv_path = tmp_path / "empty.csv"
+    csv_path.write_text("datetime_utc,datetime_local,watt_hours,cost_dollars,is_peak\n")
+    manifest_path = tmp_path / "manifest.csv"
+    manifest_path.write_text(
+        "file,start_date,end_date,start_epoch,end_epoch,downloaded_at_utc,sha256,http_status,bytes\n"
+        f"{csv_path},2024-10-01,2024-12-29,0,0,2026-01-01T00:00:00Z,abc,200,60\n"
+    )
+
+    result = loader.main(["--manifest", str(manifest_path), "--dry-run"])
+
+    captured = capsys.readouterr()
+    assert result == 0
+    assert "Empty/header-only CSV: skipped" in captured.out
+    assert "Dry run complete; no Supabase writes were attempted." in captured.out
+
+
+def test_dry_run_does_not_call_supabase(tmp_path, monkeypatch):
+    csv_path = tmp_path / "usage.csv"
+    csv_path.write_text(
+        "datetime_utc,datetime_local,watt_hours,cost_dollars,is_peak\n"
+        "2025-01-04 00:00:00,2025-01-04 11:00:00,6.0,0.01,false\n"
+    )
+
+    def fail_if_called(*args, **kwargs):
+        raise AssertionError("Supabase should not be called during dry run")
+
+    monkeypatch.setattr(loader.supabase_db, "insert_ingest_event", fail_if_called)
+    monkeypatch.setattr(loader.supabase_db, "upsert_usage_intervals", fail_if_called)
+
+    assert loader.main(["--csv", str(csv_path), "--dry-run"]) == 0
+
+
+def test_summarize_intervals_detects_duplicates_and_gaps():
+    df = pd.DataFrame({
+        "datetime_utc": [
+            "2025-01-04 00:00:00",
+            "2025-01-04 00:00:00",
+            "2025-01-04 00:03:00",
+        ],
+        "watt_hours": [1.0, 2.0, 3.0],
+    })
+    rows, na_count, parse_mode = loader.build_usage_intervals(
+        df, "datetime_utc", "watt_hours", "site", "general", "powerpal", "dry-run"
+    )
+
+    summary = loader.summarize_intervals(Path("x.csv"), len(df), rows, na_count, parse_mode)
+
+    assert summary.valid_intervals == 3
+    assert summary.duplicate_intervals == 1
+    assert summary.gap_count == 1
+    assert summary.missing_minutes == 2


### PR DESCRIPTION
Task:\n#4 Consolidate 2025 usage baseline coverage; #8 Build cross-source usage reconciliation report\nOwner:\nIngestion Pipeline Agent (#4); Supabase & Data Management Agent (#8)\nSupport:\nSupabase & Data Management Agent, Modelling Agent\n\nScope:\n- Files changed: scripts/load_powerpal_minute_to_supabase.py; scripts/compare_usage_sources.py; tests/test_powerpal_loader.py; tests/test_compare_usage_sources.py; PROJECT_PROGRESS.md\n- Out-of-scope: live Supabase load; live Amber reconciliation; schema changes\n\nBehavior changes:\n- Powerpal loader supports --manifest and --dry-run, skips header-only exports, and reports per-file plus aggregate coverage.\n- Added a Sydney-local daily usage source reconciliation report with optional CSV output.\n\nValidation run:\n- Commands: .venv/bin/python -m pytest -q tests/test_powerpal_loader.py tests/test_compare_usage_sources.py; .venv/bin/python -m pytest -q; .venv/bin/python scripts/load_powerpal_minute_to_supabase.py --manifest data_raw/powerpal_minute/manifest_powerpal_minute.csv --dry-run\n- Result: 7 passed targeted; 35 passed full suite; manifest dry-run completed successfully\n\nRisks / follow-ups:\n- Live Supabase load and Amber-vs-Powerpal reconciliation remain blocked until credentials are refreshed; local Supabase URL currently fails with Tenant or user not found.\n\nDocs updated:\n- PROJECT_PROGRESS.md: yes\n- docs/STATUS_REPORT.md: no\n- docs/pi_deployment.md: no